### PR TITLE
Enable transport option on a control settings

### DIFF
--- a/includes/functions/controls-init.php
+++ b/includes/functions/controls-init.php
@@ -63,7 +63,8 @@ function kirki_customizer_controls( $wp_customize ) {
 				$wp_customize->add_setting( $control['setting'], array(
 					'default'    => isset( $control['default'] ) ? $control['default'] : '',
 					'type'       => 'theme_mod',
-					'capability' => 'edit_theme_options'
+					'capability' => 'edit_theme_options',
+					'transport' => isset( $control['transport'] ) ? $control['transport'] : '',
 				) );
 
 			}


### PR DESCRIPTION
Per [this comments thread](https://github.com/presscodes/kirki/issues/27#issuecomment-67297364), this update enables the transport option on a control setting.

I prefer to write my own js to handle the dom updates, so I don't know how well it integrates with [includes/functions/transport.php](https://github.com/presscodes/kirki/blob/master/includes/functions/transport.php).
