### PR TITLE
Fix double output issue on automatic CSS

### DIFF
--- a/includes/class-kirki-style-generic.php
+++ b/includes/class-kirki-style-generic.php
@@ -31,7 +31,7 @@ class Kirki_Style_Generic {
 		 * Background controls are handled in the Kirki_Style_Background class.
 		 * Color controls are handled in the Kirki_Style_Color class.
 		 */
-		if ( 'color' != $control['type'] && 'background' != $control['type'] ) {
+		if ( 'color' != $control['type'] || 'background' != $control['type'] ) {
 			return;
 		}
 


### PR DESCRIPTION
When using automatic CSS generation, I experienced double output for color and background fields. Something wrong in the logic, changing "&&" to "||" does work here.
