### PR TITLE
if $subset is not 'all' cast it as array

### DIFF
--- a/includes/class-kirki-fonts.php
+++ b/includes/class-kirki-fonts.php
@@ -114,11 +114,7 @@ class Kirki_Fonts {
 
 		} else {
 
-			$subsets = array(
-				'latin',
-				$subset,
-
-			);
+			$subsets = (array)$subset;
 
 		}
 


### PR DESCRIPTION
The $subset arg passed to get_google_font_uri() can be a string ('all') or an array of subsets. So I suggest this fix to keep the array type if $subset is not 'all'.
