### PR TITLE
Use url_path if defined in user settings

### DIFF
--- a/includes/Scripts/Customizer/Dependencies.php
+++ b/includes/Scripts/Customizer/Dependencies.php
@@ -13,7 +13,7 @@ class Dependencies extends EnqueueScript {
 	public function customize_controls_enqueue_scripts() {
 
 		$controls = Kirki::config()->get_all();
-		$kirki_url = isset( $config['url_path'] ) ? $config['url_path'] : KIRKI_URL;
+		$kirki_url = isset( $controls['url_path'] ) ? $controls['url_path'] : KIRKI_URL;
 
 		wp_enqueue_script( 'kirki_customizer_js', $kirki_url . 'assets/js/customizer.js', array( 'jquery', 'customize-controls' ) );
 		wp_enqueue_script( 'serialize-js', $kirki_url . 'assets/js/serialize.js');

--- a/includes/Styles/Customizer.php
+++ b/includes/Styles/Customizer.php
@@ -15,7 +15,10 @@ class Customizer {
 	 * Enqueue the stylesheets required.
 	 */
 	function customizer_styles() {
-		wp_enqueue_style( 'kirki-customizer-css', KIRKI_URL . '/assets/css/customizer.css', NULL, '0.5' );
+		$controls = Kirki::config()->get_all();
+		$kirki_url = isset( $controls['url_path'] ) ? $controls['url_path'] : KIRKI_URL;
+
+		wp_enqueue_style( 'kirki-customizer-css', $kirki_url . '/assets/css/customizer.css', NULL, '0.5' );
 	}
 
 	/**


### PR DESCRIPTION
If user set url_path use it for loading JS and CSS assets from the correct location. 
It wasn’t being used for CSS and for JS it was reading an incorrect variable.
