### PR TITLE
Fixed units value of js_vars does not work

### DIFF
--- a/includes/class-kirki-scripts-customizer-postmessage.php
+++ b/includes/class-kirki-scripts-customizer-postmessage.php
@@ -48,7 +48,7 @@ class Kirki_Scripts_Customizer_PostMessage extends Kirki_Scripts_Enqueue_Script 
 					if ( 'html' == $js_vars['function'] ) {
 						$script .= '$( \'' . esc_js( $js_vars["element"] ) . '\' ).html( newval );';
 					} elseif ( 'css' == $js_vars['function'] ) {
-						$script .= '$(\'' . esc_js( $js_vars["element"] ) . '\').css(\'' . esc_js( $js_vars["property"] ) . '\', newval );';
+						$script .= '$(\'' . esc_js( $js_vars["element"] ) . '\').css(\'' . esc_js( $js_vars["property"] ) . '\', newval'. ( ! empty( $js_vars['units'] ) ? ' + \'' . $js_vars['units'] . "'" : '' ) .' );';
 					}
 					$script .= '}); });';
 				}


### PR DESCRIPTION
Some settings which are font-size style do not work when using post message because of missing unit value 'px'.
