### PR TITLE
Use the_link() function display data attribute for select2 controls

### DIFF
--- a/includes/controls/select2-multiple/class-kirki-controls-select2-multiple-control.php
+++ b/includes/controls/select2-multiple/class-kirki-controls-select2-multiple-control.php
@@ -47,7 +47,7 @@ class Kirki_Controls_Select2_Multiple_Control extends WP_Customize_Control {
 				<?php endif; ?>
 			</span>
 
-			<select data-customize-setting-link="<?php echo esc_attr( $id ); ?>" class="select2" multiple="multiple">
+			<select <?php $this->link(); ?> class="select2" multiple="multiple">
 				<?php foreach ( $this->choices as $value => $label ) : ?>
 					<option value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $label ); ?></option>
 				<?php endforeach; ?>

--- a/includes/controls/select2/class-kirki-controls-select2-control.php
+++ b/includes/controls/select2/class-kirki-controls-select2-control.php
@@ -47,7 +47,7 @@ class Kirki_Controls_Select2_Control extends WP_Customize_Control {
 				<?php endif; ?>
 			</span>
 
-			<select data-customize-setting-link="<?php echo esc_attr( $id ); ?>" class="select2">
+			<select <?php $this->link(); ?> class="select2">
 				<?php foreach ( $this->choices as $value => $label ) : ?>
 					<option value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $label ); ?></option>
 				<?php endforeach; ?>

--- a/tests/test-kirki.php
+++ b/tests/test-kirki.php
@@ -316,5 +316,38 @@ class Test_Kirki extends WP_UnitTestCase {
 			Kirki::get_option( 'my_config_options_serialized', 'my_option[my_settings_test_background_options_serialized]' )
 		);
 	}
+	
+	public function test_setting_with_brackets() {
+		$wp_customize = $this->init_customizer();
+		
+		$setting = 'foo[bar]';
+		
+		$wp_customize->add_setting( $setting, array(
+			'default' => ''
+		) );
+		
+		$select2 = new Kirki_Controls_Select2_Control( $wp_customize, $setting, array(
+			'settings' => $setting,
+			'choices' => array(
+				'foo' => 'bar'
+			)
+		) );
+		$select2_multiple = new Kirki_Controls_Select2_Multiple_Control( $wp_customize, $setting, array(
+			'settings' => $setting,
+			'choices' => array(
+				'foo' => 'bar'
+			)
+		) );
+		$contents = '';
+		ob_start();
+		$select2->render_content();
+		$select2_multiple->render_content();
+		$contents = ob_get_clean();
+		
+		preg_match_all('/data-customize-setting-link="(.*?)"/', $contents, $matches, PREG_SET_ORDER);
+		$links = wp_list_pluck($matches, 1);
+		
+		$this->assertEqualSets($links, array('foo[bar]', 'foo[bar]'));
+	}
 
 }


### PR DESCRIPTION
This fixes a problem where if you have a `[` or `]` in the `setting` argument for the field, it gets removed.
So for instance, if you used `setting` `foo[bar][2]` the data attribute becomes `data-customize-setting-link="foo-bar-2"`. The brackets should not get removed though, it should remain as `data-customize-setting-link="foo[bar][2]"`.

The reason is that the data binding does not work as intended if they get removed (Saved button does not change to "Save & Publish" when you change the value).

See https://github.com/WordPress/WordPress/blob/4.0.7/wp-includes/class-wp-customize-control.php#L316 for `the_link` function.
