### PR TITLE
Fix URLs in customizer when embedded in a theme

### DIFF
--- a/includes/class-kirki-init.php
+++ b/includes/class-kirki-init.php
@@ -6,7 +6,38 @@ class Kirki_Init {
 	 * the class constructor
 	 */
 	public function __construct() {
+		$this->set_url();
 		add_action( 'wp_loaded', array( $this, 'add_to_customizer' ), 1 );
+	}
+
+	/**
+	 * Properly set the Kirki URL for assets
+	 * Determines if Kirki is installed as a plugin, in a child theme, or a parent theme
+	 * and then does some calculations to get the proper URL for its CSS & JS assets
+	 *
+	 * @return string
+	 */
+	public function set_url() {
+		/**
+		 * Are we on a parent theme?
+		 */
+		if ( Kirki_Toolkit::is_parent_theme( __FILE__ ) ) {
+			$relative_url = str_replace( Kirki_Toolkit::clean_file_path( get_template_directory() ), '', dirname( dirname( __FILE__ ) ) );
+			Kirki::$url = trailingslashit( get_template_directory_uri() . $relative_url );
+		}
+		/**
+		 * Are we on a child theme?
+		 */
+		elseif ( Kirki_Toolkit::is_child_theme( __FILE__ ) ) {
+			$relative_url = str_replace( Kirki_Toolkit::clean_file_path( get_stylesheet_directory() ), '', dirname( dirname( __FILE__ ) ) );
+			Kirki::$url = trailingslashit( get_stylesheet_directory() . $relative_url );
+		}
+		/**
+		 * Fallback to plugin
+		 */
+		else {
+			Kirki::$url = plugin_dir_url( dirname( __FILE__ ) . 'kirki.php' );
+		}
 	}
 
 	/**

--- a/includes/class-kirki-toolkit.php
+++ b/includes/class-kirki-toolkit.php
@@ -137,4 +137,80 @@ final class Kirki_Toolkit {
 		return (bool) ( defined( 'KIRKI_DEBUG' ) && KIRKI_DEBUG );
 	}
 
+    /**
+     * Take a path and return it clean
+     *
+     * @param string $path
+	 * @return string
+     */
+    public static function clean_file_path( $path ) {
+        $path = str_replace( '', '', str_replace( array( "\\", "\\\\" ), '/', $path ) );
+        if ( '/' === $path[ strlen( $path ) - 1 ] ) {
+            $path = rtrim( $path, '/' );
+        }
+        return $path;
+    }
+
+	/**
+	 * Determine if we're on a parent theme
+	 *
+	 * @param $file string
+	 * @return bool
+	 */
+	public static function is_parent_theme( $file ) {
+		$file = self::clean_file_path( $file );
+		$dir  = self::clean_file_path( get_template_directory() );
+		$file = str_replace( '//', '/', $file );
+		$dir  = str_replace( '//', '/', $dir );
+		if ( false !== strpos( $file, $dir ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if we're on a child theme.
+	 *
+	 * @param $file string
+	 * @return bool
+	 */
+	public static function is_child_theme( $file ) {
+		$file = self::clean_file_path( $file );
+		$dir  = self::clean_file_path( get_stylesheet_directory() );
+		$file = str_replace( '//', '/', $file );
+		$dir  = str_replace( '//', '/', $dir );
+		if ( false !== strpos( $file, $dir ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if we're running as a plugin
+	 */
+	private static function is_plugin() {
+		if ( false !== strpos( self::clean_file_path( __FILE__ ), self::clean_file_path( get_stylesheet_directory() ) ) ) {
+			return false;
+		}
+		if ( false !== strpos( self::clean_file_path( __FILE__ ), self::clean_file_path( get_template_directory_uri() ) ) ) {
+			return false;
+		}
+		if ( false !== strpos( self::clean_file_path( __FILE__ ), self::clean_file_path( WP_CONTENT_DIR . '/themes/' ) ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Determine if we're on a theme
+	 *
+	 * @param $file string
+	 * @return bool
+	 */
+	public static function is_theme( $file ) {
+		if ( true == self::is_child_theme( $file ) || true == self::is_parent_theme( $file ) ) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/kirki.php
+++ b/kirki.php
@@ -45,28 +45,6 @@ if ( ! function_exists( 'Kirki' ) ) {
 		 * The path of the current Kirki instance
 		 */
 		Kirki::$path = dirname( __FILE__ );
-		/**
-		 * Get the URL of the current Kirki instance.
-		 * In order to do that, first we'll have to determine if we're using Kirki
-		 * as a plugin, or if it's embedded in a theme.
-		 * We'll also have to do some ugly stuff below because Windows is messy
-		 * and we want to accomodate users using XAMPP for their development.
-		 * Seriously though guys, you should consider using Vagrant instead.
-		 */
-		$dirname_no_slashes   = str_replace( array( '\\', '/' ), '', dirname( __FILE__ ) );
-		$plugindir_no_slashes = str_replace( array( '\\', '/' ), '', WP_PLUGIN_DIR );
-		$themedir_no_slashes  = str_replace( array( '\\', '/' ), '', get_template_directory() );
-		if ( false !== strpos( $dirname_no_slashes, $plugindir_no_slashes ) ) {
-			/**
-			 * Kirki is activated as a plugin.
-			 */
-			Kirki::$url = plugin_dir_url( __FILE__ );
-		} else if ( false !== strpos( $dirname_no_slashes, $themedir_no_slashes ) ) {
-			/**
-			 * Kirki is embedded in a theme
-			 */
-			Kirki::$url = get_template_directory_uri() . str_replace( get_template_directory(), '', dirname( __FILE__ ) );
-		}
 
 		return $kirki;
 


### PR DESCRIPTION
This auto-detects if Kirki is installed in a parent theme, in a child theme, or as a plugin.
Depending on the use case we now auto-calculate the URL.
There's no need to define a URL in the configuration anymore.
