### PR TITLE
Fix code type refresh

### DIFF
--- a/assets/js/controls/code.js
+++ b/assets/js/controls/code.js
@@ -16,5 +16,9 @@ wp.customize.controlConstructor['code'] = wp.customize.Control.extend( {
 		editor.on('change', function() {
 			control.setting.set( editor.getValue() );
 		});
+
+		element.parents('.accordion-section').on('click', function(e){
+		    editor.refresh();
+		});
 	}
 });


### PR DESCRIPTION
Fixes behavior when first opening a section containing a code type in which the codemirror instance is empty until you click inside it.
