### PR TITLE
Update class-kirki-customizer-scripts-tooltips.php

### DIFF
--- a/includes/class-kirki-customizer-scripts-tooltips.php
+++ b/includes/class-kirki-customizer-scripts-tooltips.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'Kirki_Scripts_Customizer_Tooltips' ) ) {
+if ( ! class_exists( 'Kirki_Customizer_Scripts_Tooltips' ) ) {
 	class Kirki_Customizer_Scripts_Tooltips extends Kirki_Customizer_Scripts {
 
 		/**


### PR DESCRIPTION
Simple mistake in class-kirki-customizer-scripts-tooltips.php on line 18 - Typo.
Wrong class name breaks entire Kirki - fixed.
