### PR TITLE
Added get_terms helper function

### DIFF
--- a/includes/class-kirki-helper.php
+++ b/includes/class-kirki-helper.php
@@ -140,6 +140,21 @@ if ( ! class_exists( 'Kirki_Helper' ) ) {
 			return $items;
 
 		}
+		
+		public static function get_terms( $taxonomies ) {
+
+			$items = array();
+
+			// Get the post types
+			$terms = get_terms( $taxonomies );
+			// Build the array
+			foreach ( $terms as $term ) {
+				$items[ $term->term_id ] = $term->name;
+			}
+
+			return $items;
+
+		}
 
 	}
 }


### PR DESCRIPTION
Added a helper function to get a list of available terms, useful when adding a select picker for a term or a group of terms

the function can take a **string** or an **array** like:

``` php
get_terms( 'category' );
get_terms( array( 'category', 'post_tag' ) );
```
