### PR TITLE
Fixing nested control descriptions

### DIFF
--- a/includes/controls/class-kirki-controls-color-alpha-control.php
+++ b/includes/controls/class-kirki-controls-color-alpha-control.php
@@ -45,10 +45,10 @@ if ( ! class_exists( 'Kirki_Controls_Color_Alpha_Control' ) ) {
 			<label>
 				<span class="customize-control-title">
 					{{{ data.label }}}
-					<# if ( data.description ) { #>
-						<span class="description customize-control-description">{{ data.description }}</span>
-					<# } #>
 				</span>
+                <# if ( data.description ) { #>
+                    <span class="description customize-control-description">{{ data.description }}</span>
+                <# } #>
 				<input type="text" data-palette="{{ data.palette }}" data-default-color="{{ data.default }}" data-alpha="true" value="{{ data.value }}" class="kirki-color-control color-picker" {{{ data.link }}} />
 			</label>
 		<?php }

--- a/includes/controls/class-kirki-controls-color-control.php
+++ b/includes/controls/class-kirki-controls-color-control.php
@@ -45,10 +45,10 @@ if ( ! class_exists( 'Kirki_Controls_Color_Control' ) ) {
 			<label>
 				<span class="customize-control-title">
 					{{{ data.label }}}
-					<# if ( data.description ) { #>
-						<span class="description customize-control-description">{{ data.description }}</span>
-					<# } #>
 				</span>
+                <# if ( data.description ) { #>
+                    <span class="description customize-control-description">{{ data.description }}</span>
+                <# } #>
 				<input type="text" data-palette="{{ data.palette }}" data-default-color="{{ data.default }}" data-alpha="false" value="{{ data.value }}" class="kirki-color-control color-picker" {{{ data.link }}} />
 			</label>
 		<?php }

--- a/includes/controls/class-kirki-controls-editor-control.php
+++ b/includes/controls/class-kirki-controls-editor-control.php
@@ -29,10 +29,10 @@ if ( ! class_exists( 'Kirki_Controls_Editor_Control' ) ) {
 			<label>
 				<span class="customize-control-title">
 					<?php echo esc_html( $this->label ); ?>
-					<?php if ( ! empty( $this->description ) ) : ?>
-						<span class="description customize-control-description"><?php echo $this->description; ?></span>
-					<?php endif; ?>
 				</span>
+				<?php if ( ! empty( $this->description ) ) : ?>
+                    <span class="description customize-control-description"><?php echo $this->description; ?></span>
+                <?php endif; ?>
 				<?php
 					$settings = array(
 						'textarea_name' => $this->id,

--- a/includes/controls/class-kirki-controls-palette-control.php
+++ b/includes/controls/class-kirki-controls-palette-control.php
@@ -31,11 +31,10 @@ if ( ! class_exists( 'Kirki_Controls_Palette_Control' ) ) {
 			<# if ( ! data.choices ) { return; } #>
 			<span class="customize-control-title">
 				{{ data.label }}
-				<# if ( data.description ) { #>
-					<span class="description customize-control-description">{{ data.description }}</span>
-				<# } #>
 			</span>
-
+            <# if ( data.description ) { #>
+                <span class="description customize-control-description">{{ data.description }}</span>
+            <# } #>
 			<div id="input_{{ data.id }}" class="buttonset">
 				<# for ( key in data.choices ) { #>
 					<input type="radio" value="{{ key }}" name="_customize-palette-{{ data.id }}" id="{{ data.id }}{{ key }}" {{{ data.link }}}<# if ( data.value == key ) { #> checked<# } #>>

--- a/includes/controls/class-kirki-controls-sortable-control.php
+++ b/includes/controls/class-kirki-controls-sortable-control.php
@@ -78,10 +78,10 @@ if ( ! class_exists( 'Kirki_Controls_Sortable_Control' ) ) {
 			<label class='kirki-sortable'>
 				<span class="customize-control-title">
 					{{{ data.label }}}
-					<?php if ( ! empty( $this->description ) ) : ?>
-						<span class="description customize-control-description"><?php echo $this->description; ?></span>
-					<?php endif; ?>
 				</span>
+				<?php if ( ! empty( $this->description ) ) : ?>
+                    <span class="description customize-control-description"><?php echo $this->description; ?></span>
+                <?php endif; ?>
 
 				<ul class="sortable">
 					<# for ( i in data.filteredValues ) { #>

--- a/includes/controls/class-kirki-controls-switch-control.php
+++ b/includes/controls/class-kirki-controls-switch-control.php
@@ -35,10 +35,10 @@ if ( ! class_exists( 'Kirki_Controls_Switch_Control' ) ) {
 			<div class="switch<# if ( data.choices['round'] ) { #> round<# } #>">
 				<span class="customize-control-title">
 					{{{ data.label }}}
-					<# if ( data.description ) { #>
-						<span class="description customize-control-description">{{{ data.description }}}</span>
-					<# } #>
 				</span>
+                <# if ( data.description ) { #>
+                    <span class="description customize-control-description">{{{ data.description }}}</span>
+                <# } #>
 				<input name="switch_{{ data.id }}" id="switch_{{ data.id }}" type="checkbox" value="{{ data.value }}" {{{ data.link }}}<# if ( '1' == data.value ) { #> checked<# } #> />
 				<label class="switch-label" for="switch_{{ data.id }}">
 					<span class="switch-on">{{ data.choices['on'] }}</span>

--- a/includes/controls/class-kirki-controls-toggle-control.php
+++ b/includes/controls/class-kirki-controls-toggle-control.php
@@ -26,10 +26,10 @@ if ( ! class_exists( 'Kirki_Controls_Toggle_Control' ) ) {
 			<label for="toggle_{{ data.id }}">
 				<span class="customize-control-title">
 					{{{ data.label }}}
-					<# if ( data.description ) { #>
-						<span class="description customize-control-description">{{{ data.description }}}</span>
-					<# } #>
 				</span>
+                <# if ( data.description ) { #>
+                    <span class="description customize-control-description">{{{ data.description }}}</span>
+                <# } #>
 				<input name="toggle_{{ data.id }}" id="toggle_{{ data.id }}" type="checkbox" value="{{ data.value }}" {{{ data.link }}}<# if ( '1' == data.value ) { #> checked<# } #> hidden />
 				<span  class="switch"></span>
 			</label>


### PR DESCRIPTION
It’s impossible to properly style .customize-control-description SPAN
element while nested inside .customize-control-title SPAN.
