### PR TITLE
Update radio-image.md

### DIFF
--- a/docs/controls/radio-image.md
+++ b/docs/controls/radio-image.md
@@ -28,7 +28,7 @@ Argument            | Required | Type              | Description
 
 ```php
 Kirki::add_field( 'my_config', array(
-	'type'        => 'radio',
+	'type'        => 'radio-image',
 	'settings'    => 'my_setting',
 	'label'       => __( 'Radio Control', 'my_textdomain' ),
 	'section'     => 'radio',


### PR DESCRIPTION
I have been using this docs for my field types, please correct the 'type' => 'radio' for 'type' => 'radio-image' since it does not work using only radio.

I came accross this because I was checking an issue regarding radio image not working, and it was not working for me until i found out this small change
