### PR TITLE
Fixed default value for the letter-spacing setting in the typography control

### DIFF
--- a/includes/class-kirki-sanitize-values.php
+++ b/includes/class-kirki-sanitize-values.php
@@ -156,7 +156,7 @@ if ( ! class_exists( 'Kirki_Sanitize_Values' ) ) {
 			}
 			// Sanitize the letter-spacing
 			if ( isset( $value['letter-spacing'] ) && ! empty( $value['letter-spacing'] ) ) {
-				$value['letter-spacing'] = self::css_dimension( $value['font-size'] );
+				$value['letter-spacing'] = self::css_dimension( $value['letter-spacing'] );
 				if ( $value['letter-spacing'] == self::filter_number( $value['letter-spacing'] ) ) {
 					$value['letter-spacing'] .= 'px';
 				}


### PR DESCRIPTION
Make sure that we get the correct default value for the letter-spacing
setting in the typography control, instead of falling back to the
font-size value.
