### PR TITLE
Make sure that CSS output doesn't contain escaped quotes.

### DIFF
--- a/includes/class-kirki-values.php
+++ b/includes/class-kirki-values.php
@@ -148,6 +148,15 @@ if ( ! class_exists( 'Kirki_Values' ) ) {
 				}
 			}
 
+			if ( is_array( $value ) ) {
+				foreach ( $value as $key => $v ) {
+					$value[$key] = html_entity_decode( $v );
+				}
+			}
+			else {
+				$value = html_entity_decode( $value );
+			}
+
 			return $value;
 
 		}


### PR DESCRIPTION
Hi,

this is probably not the best way to handle this error, but I figured I might let you know about it anyway. It's easy to replicate: just create a Typography control and try and associate the "Monospace" value to it. The following is what's being output:

`h1{font-family:"Monaco,&quot;Lucida Sans Typewriter&quot;,&quot;Lucida Typewriter&quot;,&quot;Courier New&quot;,Courier,monospace";`

As you can see, double quotes are escaped, which leads to broken styles on frontend. Since escaped quotes aren't useful in CSS, I thought that maybe we could get rid of entities altogether, when getting a field's value.

Thoughts?
