### PR TITLE
Change markup for the Editor Field

### DIFF
--- a/includes/controls/class-kirki-controls-editor-control.php
+++ b/includes/controls/class-kirki-controls-editor-control.php
@@ -35,19 +35,19 @@ if ( ! class_exists( 'Kirki_Controls_Editor_Control' ) ) {
 					<?php echo esc_html( $this->label ); ?>
 				</span>
 			</label>
-				<?php if ( ! empty( $this->description ) ) : ?>
-					<span class="description customize-control-description"><?php echo $this->description; ?></span>
-				<?php endif; ?>
-				<?php
-					$settings = array(
-						'textarea_name' => $this->id,
-						'teeny'         => true,
-					);
-					add_filter( 'the_editor', array( $this, 'filter_editor_setting_link' ) );
-					wp_editor( html_entity_decode( wp_kses_post( $this->value() ) ), $this->id, $settings );
+			<?php if ( ! empty( $this->description ) ) : ?>
+				<span class="description customize-control-description"><?php echo $this->description; ?></span>
+			<?php endif; ?>
+			<?php
+				$settings = array(
+					'textarea_name' => $this->id,
+					'teeny'         => true,
+				);
+				add_filter( 'the_editor', array( $this, 'filter_editor_setting_link' ) );
+				wp_editor( html_entity_decode( wp_kses_post( $this->value() ) ), $this->id, $settings );
 
-					do_action( 'admin_footer' );
-					do_action( 'admin_print_footer_scripts' );
+				do_action( 'admin_footer' );
+				do_action( 'admin_print_footer_scripts' );
 		}
 
 		/**

--- a/includes/controls/class-kirki-controls-editor-control.php
+++ b/includes/controls/class-kirki-controls-editor-control.php
@@ -34,6 +34,7 @@ if ( ! class_exists( 'Kirki_Controls_Editor_Control' ) ) {
 				<span class="customize-control-title">
 					<?php echo esc_html( $this->label ); ?>
 				</span>
+			</label>
 				<?php if ( ! empty( $this->description ) ) : ?>
 					<span class="description customize-control-description"><?php echo $this->description; ?></span>
 				<?php endif; ?>
@@ -47,9 +48,6 @@ if ( ! class_exists( 'Kirki_Controls_Editor_Control' ) ) {
 
 					do_action( 'admin_footer' );
 					do_action( 'admin_print_footer_scripts' );
-				?>
-			</label>
-			<?php
 		}
 
 		/**


### PR DESCRIPTION
The current implementation has the entire WYSIWYG editor wrapped inside a `label`.
This is causing some problems because since the label has no `for` attribute every time a user clicks anywhere in the field the click automatically triggers the media uploader modal since the media button is the first actionable input inside the filed.
So we can either add a for attribute or, as I've done in the pull, wrap only the span with the title inside the label.
