### PR TITLE
Fix to #879

### DIFF
--- a/includes/field/class-kirki-field-checkbox.php
+++ b/includes/field/class-kirki-field-checkbox.php
@@ -1,7 +1,19 @@
 <?php
+/**
+ * Override field methods
+ *
+ * @package     Kirki
+ * @subpackage  Controls
+ * @copyright   Copyright (c) 2016, Aristeides Stathopoulos
+ * @license     http://opensource.org/licenses/https://opensource.org/licenses/MIT
+ * @since       2.2.7
+ */
 
 if ( ! class_exists( 'Kirki_Field_Checkbox' ) ) {
 
+	/**
+	 * Field overrides.
+	 */
 	class Kirki_Field_Checkbox extends Kirki_Field {
 
 		/**
@@ -21,33 +33,55 @@ if ( ! class_exists( 'Kirki_Field_Checkbox' ) ) {
 		}
 
 		/**
-		 * Sets the $sanitize_callback
+		 * Sets the $sanitize_callback.
 		 *
 		 * @access protected
 		 */
 		protected function set_sanitize_callback() {
 
-			$this->sanitize_callback = array( 'Kirki_Sanitize_Values', 'checkbox' );
+			$this->sanitize_callback = array( 'Kirki_Field_Checkbox', 'sanitize' );
 
 		}
 
 		/**
-		 * Sets the default value
+		 * Sanitizes checkbox values.
+		 *
+		 * @static
+		 * @access public
+		 * @param bool|string $value The checkbox value.
+		 * @return bool
+		 */
+		public static function sanitize( $value = null ) {
+
+			// If the value is not set, return false.
+			if ( is_null( $value ) ) {
+				return '0';
+			}
+
+			// Check for checked values.
+			if ( 1 === $value || '1' === $value || true === $value || 'on' === $value ) {
+				return '1';
+			}
+
+			// Fallback to false.
+			return '0';
+
+		}
+
+		/**
+		 * Sets the default value.
 		 *
 		 * @access protected
 		 */
 		protected function set_default() {
 
-			if ( false === $this->default || 0 === $this->default ) {
+			if ( false === $this->default || 0 === $this->default || '0' === $this->default || 'off' === $this->default) {
 				$this->default = '0';
 			}
 
-			if ( true === $this->default || 1 === $this->default ) {
+			if ( true === $this->default || 1 === $this->default || '1' === $this->default || 'on' === $this->default) {
 				$this->default = '1';
 			}
-
 		}
-
 	}
-
 }


### PR DESCRIPTION
As stated in the title this one is a possible fix to #879 plus a tiny improvement in the way default values are set.

Just a tiny tweak but it seems from my testings that switching from returning booleans to returning strings in the `sanitize` method fixes the issue.
The value is now correctly inserted in the db where we now have the `option_value` set to `0` instead of having an empty cell which I think is even better.

I've also tweaked the conditions for the `if` inside the `set_default` method in order to be consistent with the check we're performing in the `sanitize` method a few lines above.
