### PR TITLE
Update class-kirki-controls-date-control.php - missing doublequote

### DIFF
--- a/includes/controls/class-kirki-controls-date-control.php
+++ b/includes/controls/class-kirki-controls-date-control.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'Kirki_Controls_Date_Control' ) ) {
 					<span class="description customize-control-description">{{{ data.description }}}</span>
 				<# } #>
 				<div class="customize-control-content">
-					<input class="datepicker" type="text" id={{ data.id }}" value="{{ data.value }}" {{{ data.link }}} />
+					<input class="datepicker" type="text" id="{{ data.id }}" value="{{ data.value }}" {{{ data.link }}} />
 				</div>
 			</label>
 			<?php


### PR DESCRIPTION
missing a doublequote before the id-attribute of the datepicker input element
