### PR TITLE
CSS prefixes order fixes & 'suffix' output argument support in Multicolor control

### DIFF
--- a/includes/output/field/class-kirki-output-field-multicolor.php
+++ b/includes/output/field/class-kirki-output-field-multicolor.php
@@ -52,8 +52,11 @@ if ( ! class_exists( 'Kirki_Output_Field_Multicolor' ) ) {
 					$output['media_query'] = 'global';
 				}
 
+				// If "suffix" is defined, add it to the value.
+				$output['suffix'] = ( isset( $output['suffix'] ) ) ? $output['suffix'] : '';
+
 				// Create the styles.
-				$this->styles[ $output['media_query'] ][ $output['element'] ][ $output['property'] ] = $sub_value;
+				$this->styles[ $output['media_query'] ][ $output['element'] ][ $output['property'] ] = $sub_value . $output['suffix'];
 
 			}
 		}

--- a/includes/styles/class-kirki-styles-output-css.php
+++ b/includes/styles/class-kirki-styles-output-css.php
@@ -225,7 +225,7 @@ if ( ! class_exists( 'Kirki_Styles_Output_CSS' ) ) {
 					foreach ( $elements as $element => $style_array ) {
 						foreach ( $style_array as $property => $value ) {
 
-							// Add -webkit-* and -mod-*.
+							// Add -webkit-* and -moz-*.
 							if ( is_string( $property ) && in_array( $property, array(
 								'border-radius',
 								'box-shadow',
@@ -236,8 +236,10 @@ if ( ! class_exists( 'Kirki_Styles_Output_CSS' ) ) {
 								'transition',
 								'transition-property',
 							) ) ) {
+								unset( $css[ $media_query ][ $element ][ $property ] );
 								$css[ $media_query ][ $element ][ '-webkit-' . $property ] = $value;
 								$css[ $media_query ][ $element ][ '-moz-' . $property ]    = $value;
+								$css[ $media_query ][ $element ][ $property ]              = $value;
 							}
 
 							// Add -ms-* and -o-*.
@@ -247,8 +249,10 @@ if ( ! class_exists( 'Kirki_Styles_Output_CSS' ) ) {
 								'transition',
 								'transition-property',
 							) ) ) {
+								unset( $css[ $media_query ][ $element ][ $property ] );
 								$css[ $media_query ][ $element ][ '-ms-' . $property ] = $value;
 								$css[ $media_query ][ $element ][ '-o-' . $property ]  = $value;
+								$css[ $media_query ][ $element ][ $property ]          = $value;
 							}
 						}
 					}


### PR DESCRIPTION
Property without prefix should be at the end

Before/after:

![bef](https://cloud.githubusercontent.com/assets/4136507/16580755/1cb16a54-42b7-11e6-82db-b3f68d13d1f0.png)  - - - -> ![aft](https://cloud.githubusercontent.com/assets/4136507/16580759/219fbb10-42b7-11e6-9312-827efa2025fc.png)
