### PR TITLE
'elements' sort order in CSS output

### DIFF
--- a/includes/output/class-kirki-output.php
+++ b/includes/output/class-kirki-output.php
@@ -148,7 +148,6 @@ if ( ! class_exists( 'Kirki_Output' ) ) {
 
 				if ( isset( $output['element'] ) && is_array( $output['element'] ) ) {
 					$output['element'] = array_unique( $output['element'] );
-					sort( $output['element'] );
 					$output['element'] = implode( ',', $output['element'] );
 				}
 


### PR DESCRIPTION
CSS output should have the original order of array elements if `elements` is an array. It helps in debugging.
