### PR TITLE
Avoid php notice when font variant is not shown for the field

### DIFF
--- a/field/class-kirki-field-typography.php
+++ b/field/class-kirki-field-typography.php
@@ -123,7 +123,9 @@ class Kirki_Field_Typography extends Kirki_Field {
 		}
 
 		// Use 'regular' instead of 400 for font-variant.
-		$value['variant'] = ( 400 === $value['variant'] || '400' === $value['variant'] ) ? 'regular' : $value['variant'];
+		if ( isset( $value['variant'] ) ) {
+			$value['variant'] = ( 400 === $value['variant'] || '400' === $value['variant'] ) ? 'regular' : $value['variant'];
+		}
 
 		// Get font-weight from variant.
 		if ( ! isset( $value['font-weight'] ) && isset( $value['variant'] ) ) {


### PR DESCRIPTION
Here is sample configuration for the isssue

```
Kirki::add_field( 'my_config', array(
	'type'        => 'typography',
	'settings'    => 'vw_h1',
	'label'       => esc_html__( 'H1', 'theme' ),
	'section'     => 'section_general_typography',
	'default'     => array(
		'font-size'        => '36px',
	),
) );
```