### PR TITLE
Fix error when font family is not present

### DIFF
--- a/controls/typography/typography.js
+++ b/controls/typography/typography.js
@@ -116,7 +116,9 @@ wp.customize.controlConstructor['kirki-typography'] = wp.customize.Control.exten
 		});
 
 		// Set the initial value.
-		fontSelect.val( value['font-family'].replace( /'/g, '"' ) ).trigger( 'change' );
+		if ( value['font-family'] ) {
+			fontSelect.val( value['font-family'].replace( /'/g, '"' ) ).trigger( 'change' );
+		}
 
 		// When the value changes
 		fontSelect.on( 'change', function() {
@@ -323,7 +325,7 @@ wp.customize.controlConstructor['kirki-typography'] = wp.customize.Control.exten
 
 		var variants = false;
 		_.each( fonts.standard, function( font ) {
-			if ( font.family === fontFamily.replace( /'/g, '"' ) ) {
+			if ( fontFamily && font.family === fontFamily.replace( /'/g, '"' ) ) {
 				variants = font.variants;
 				return font.variants;
 			}


### PR DESCRIPTION
Here is sample configuration for the issue

```
Kirki::add_field( 'my_config', array(
	'type'        => 'typography',
	'settings'    => 'vw_h1',
	'label'       => esc_html__( 'H1', 'theme' ),
	'section'     => 'section_general_typography',
	'default'     => array(
		'font-size'        => '36px',
	),
) );
```