### PR TITLE
Avoid conflict with other plugin that also using Select2

### DIFF
--- a/assets/vendor/select2/kirki.css
+++ b/assets/vendor/select2/kirki.css
@@ -1,4 +1,3 @@
-@import url(css/select2.css);
 .select2-dropdown {
   border-color: rgba(0, 0, 0, 0.1);
   border-radius: 0; }

--- a/assets/vendor/select2/kirki.scss
+++ b/assets/vendor/select2/kirki.scss
@@ -1,5 +1,3 @@
-@import 'css/select2.css';
-
 .select2-dropdown {
   border-color: rgba(0,0,0,.1);
   border-radius: 0;

--- a/controls/fontawesome/class-kirki-control-fontawesome.php
+++ b/controls/fontawesome/class-kirki-control-fontawesome.php
@@ -63,7 +63,8 @@ class Kirki_Control_FontAwesome extends WP_Customize_Control {
 			wp_enqueue_style( 'kirki-fontawesome-font-css', trailingslashit( Kirki::$url ) . 'controls/fontawesome/font-awesome.css', null );
 		}
 		wp_enqueue_script( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/js/select2.full.js', array( 'jquery' ), false, true );
-		wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
+		wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/css/select2.css', null );
+		wp_enqueue_style( 'kirki-select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
 		wp_localize_script( $script_to_localize, 'fontAwesomeJSON', file_get_contents( Kirki::$path . '/controls/fontawesome/fontawesome.json' ) );
 	}
 

--- a/controls/repeater/class-kirki-control-repeater.php
+++ b/controls/repeater/class-kirki-control-repeater.php
@@ -249,7 +249,8 @@ class Kirki_Control_Repeater extends WP_Customize_Control {
 						case 'select':
 						case 'dropdown-pages':
 							wp_enqueue_script( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/js/select2.full.js', array( 'jquery' ), false, true );
-							wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
+							wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/css/select2.css', null );
+							wp_enqueue_style( 'kirki-select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
 							break;
 					}
 				}

--- a/controls/select/class-kirki-control-select.php
+++ b/controls/select/class-kirki-control-select.php
@@ -69,7 +69,8 @@ class Kirki_Control_Select extends WP_Customize_Control {
 			wp_enqueue_style( 'kirki-select-css', trailingslashit( Kirki::$url ) . 'controls/select/select.css', null );
 		}
 		wp_enqueue_script( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/js/select2.full.js', array( 'jquery' ), false, true );
-		wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
+		wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/css/select2.css', null );
+		wp_enqueue_style( 'kirki-select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
 	}
 
 	/**

--- a/controls/typography/class-kirki-control-typography.php
+++ b/controls/typography/class-kirki-control-typography.php
@@ -121,7 +121,8 @@ class Kirki_Control_Typography extends WP_Customize_Control {
 		}
 
 		wp_enqueue_script( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/js/select2.full.js', array( 'jquery' ), false, true );
-		wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
+		wp_enqueue_style( 'select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/css/select2.css', null );
+		wp_enqueue_style( 'kirki-select2', trailingslashit( Kirki::$url ) . 'assets/vendor/select2/kirki.css', null );
 
 		$custom_fonts_array = ( isset( $this->choices['fonts'] ) && ( isset( $this->choices['fonts']['google'] ) || isset( $this->choices['fonts']['standard'] ) ) && ( ! empty( $this->choices['fonts']['google'] ) || ! empty( $this->choices['fonts']['standard'] ) ) );
 		$localize_script_var_name = ( $custom_fonts_array ) ? 'kirkiFonts' . $this->id : 'kirkiAllFonts';


### PR DESCRIPTION
If user has other plugin that using Select2 (such as ACF Pro), The file `assets/vendor/select2/kirki.css` will not be loaded because it has the same handle. Separate a custom css from Select2's original css is better compatibility.