### PR TITLE
Appearing Insert/edit link Box

### DIFF
--- a/controls/editor/editor.scss
+++ b/controls/editor/editor.scss
@@ -28,8 +28,3 @@ div.mce-inline-toolbar-grp {
     z-index: 500000 !important;
   }
 }
-
-#wp-link-wrap,
-.mce-tooltip {
-  z-index: 500000 !important;
-}


### PR DESCRIPTION
If there is z-index, it display box behind transparent black background image so unable to insert link. When remove z-index, it display box properly.