### PR TITLE
customize-preview height issue

### DIFF
--- a/controls/editor/editor.scss
+++ b/controls/editor/editor.scss
@@ -87,3 +87,9 @@ div.mce-inline-toolbar-grp {
     z-index: 500000 !important;
   }
 }
+
+#customize-preview {
+	&.is-kirki-editor-open{
+		height: calc(100% - 301px);
+	}
+}


### PR DESCRIPTION
Customize preview display behind editor. It sets proper height. Copied from old version.