### PR TITLE
Fix bug preventing custom args from being passed to custom controls

### DIFF
--- a/core/class-kirki-field.php
+++ b/core/class-kirki-field.php
@@ -407,7 +407,7 @@ class Kirki_Field {
 		}
 
 		// Get all arguments with their values.
-		$args = get_class_vars( __CLASS__ );
+		$args = get_object_vars( $this );
 		foreach ( $args as $key => $default_value ) {
 			$args[ $key ] = $this->$key;
 		}


### PR DESCRIPTION
Referent to #1425 
The problem here lies on the fact that `get_class_vars` only gets the default class vars, not the ones that are set later by doing `$this->var = ...`.  On the other hand `get_object_vars` get's the defined vars on the current instance.

As I mentioned on the issue, I am no PHP/WP specialist, so I  may not be aware of other implications this change might have, feel free to ignore this PR and fix it yourself or just let me know something I else I might have to take care.

Also, I have to say, thanks for this plugin, it's really neat 👍 ..It's saving me a lot of time