### PR TITLE
Adds alpha option to multicolor control

### DIFF
--- a/controls/multicolor/class-kirki-control-multicolor.php
+++ b/controls/multicolor/class-kirki-control-multicolor.php
@@ -44,6 +44,14 @@ class Kirki_Control_Multicolor extends WP_Customize_Control {
 	public $option_type = 'theme_mod';
 
 	/**
+	 * Enable/Disable Alpha channel on color pickers
+	 *
+	 * @access public
+	 * @var boolean
+	 */
+	public $alpha = true;
+
+	/**
 	 * Constructor.
 	 *
 	 * Supplied `$args` override class property defaults.
@@ -72,6 +80,7 @@ class Kirki_Control_Multicolor extends WP_Customize_Control {
 	 *     @type array                $choices         List of choices for 'radio' or 'select' type controls, where
 	 *                                                 values are the keys, and labels are the values.
 	 *                                                 Default empty array.
+	 *     @type boolean              $alpha           Enables/Disables alpha channel on color pickers
 	 *     @type array                $input_attrs     List of custom input attributes for control output, where
 	 *                                                 attribute names are the keys and values are the values. Not
 	 *                                                 used for 'checkbox', 'radio', 'select', 'textarea', or
@@ -129,6 +138,7 @@ class Kirki_Control_Multicolor extends WP_Customize_Control {
 		$this->json['choices'] = $this->choices;
 		$this->json['link']    = $this->get_link();
 		$this->json['id']      = $this->id;
+		$this->json['alpha']   = $this->alpha;
 
 		$this->json['inputAttrs'] = '';
 		foreach ( $this->input_attrs as $attr => $value ) {
@@ -162,7 +172,7 @@ class Kirki_Control_Multicolor extends WP_Customize_Control {
 						<# if ( data.choices[ key ] ) { #>
 							<label for="{{ data.id }}-{{ key }}">{{ data.choices[ key ] }}</label>
 						<# } #>
-						<input {{{ data.inputAttrs }}} id="{{ data.id }}-{{ key }}" type="text" data-palette="{{ data.palette }}" data-default-color="{{ data.default[ key ] }}" data-alpha="true" value="{{ data.value[ key ] }}" class="kirki-color-control color-picker multicolor-index-{{ key }}" />
+						<input {{{ data.inputAttrs }}} id="{{ data.id }}-{{ key }}" type="text" data-palette="{{ data.palette }}" data-default-color="{{ data.default[ key ] }}" data-alpha="{{ data.alpha }}" value="{{ data.value[ key ] }}" class="kirki-color-control color-picker multicolor-index-{{ key }}" />
 					</div>
 				<# } #>
 			<# } #>


### PR DESCRIPTION
ref #1321
I also needed this, so I implemented it. 

One difference from the `color` control is that it passes the alpha argument inside  the `choices`arg, like
```
'choices' => array(
    'alpha' => true,
),
```

but as multicolor is already using 'choices' arg for color options, I put it on the `$args` root. Just let me know if you have a better idea.

Another difference from `color` control is that `alpha` is disabled by default there. That's a case where one would have to choose between consistency and legacy support. I've chosen legacy here and set it as enabled by default, let me know if you think it should be the opposite.

