### PR TITLE
Correctly registering custom control types

### DIFF
--- a/core/class-kirki-init.php
+++ b/core/class-kirki-init.php
@@ -163,14 +163,24 @@ class Kirki_Init {
 		foreach ( $section_types as $section_type ) {
 			$wp_customize->register_section_type( $section_type );
 		}
+
 		if ( empty( $this->control_types ) ) {
-			$this->control_types = $this->default_control_types();
+			$control_types = apply_filters( 'kirki/control_types', array() );
+			foreach ( $control_types as $key => $classname ) {
+				if ( ! class_exists( $classname ) ) {
+					unset( $control_types[ $key ] );
+				}
+			}
+
+			$this->control_types = array_merge( $control_types, $this->control_types );
 		}
+
 		$do_not_register_control_types = apply_filters( 'kirki/control_types/exclude', array(
 			'Kirki_Control_Repeater',
 		) );
+
 		foreach ( $this->control_types as $control_type ) {
-			if ( 0 === strpos( $control_type, 'Kirki' ) && ! in_array( $control_type, $do_not_register_control_types, true ) && class_exists( $control_type ) ) {
+			if ( ! in_array( $control_type, $do_not_register_control_types, true ) && class_exists( $control_type ) ) {
 				$wp_customize->register_control_type( $control_type );
 			}
 		}


### PR DESCRIPTION
Ok, I'm a bit in the dark on this one. Perhaps I just got it wrong, but here's what I found.
I tried to create a custom control as explained on https://aristath.github.io/kirki/docs/advanced/register-control-types.html
It wasn't working, so I started to investigate and find out that the only place the `kirki/control_types` filter was being applied, was on this class
https://github.com/aristath/kirki/blob/f4641ea53f17f3a8fb4874d9c0c6625466d8c2b0/core/class-kirki-control.php
which only use  them on the line 
`$this->wp_customize->add_control( new $class_name( $this->wp_customize, $args['settings'], $args ) );`
($class_name is taken from  the result of  the `kirki/control_types` filter)

so I applied `kirki/control_types` on the method that actually registers control types, and for that I had to remove the filter that only allows controls prefixed with 'Kirki'.

As I said, maybe I'm just missing something. Please, let me know
