### PR TITLE
Fix checkbox field sanitization

### DIFF
--- a/field/class-kirki-field-checkbox.php
+++ b/field/class-kirki-field-checkbox.php
@@ -51,11 +51,11 @@ class Kirki_Field_Checkbox extends Kirki_Field {
 
 			case '0':
 			case 0:
-			case 'false':
+			case 'false' === $value:
 				return false;
 			case '1':
 			case 1:
-			case 'true':
+			case 'true' === $value:
 				return true;
 		}
 


### PR DESCRIPTION
ref: #1462 
It seems that a bug was introduced on this commit https://github.com/aristath/kirki/commit/7a6a6f7104075c90881693e0f23774057c821e15?diff=unified

It happens that the php switch make comparisons equivalent to `==` operands instead of `===`, and it behaves differently when one try to evaluate if `true == "true"` instead of `true === "true"`

If you do want to stick with a switch, I suggest the fix I'm sending.. Although to be honest I do find it a bit hacky, and I'd rather go back to if statements.
just let me know what you think

Edit: Thinking about it now, couldn't we just dump support to `"false"` and `"true"`?