### PR TITLE
Reset fallback to custom controls

### DIFF
--- a/modules/reset/set-setting-value.js
+++ b/modules/reset/set-setting-value.js
@@ -17,19 +17,22 @@ if ( _.isUndefined( window.kirkiSetSettingValue ) ) {
 			 * and determine if we need to do any further work based on those.
 			 */
 			var $this = this,
-			    subControl = wp.customize.settings.controls[ setting ],
-			    valueJSON;
+				control = wp.customize.control(setting),
+				controlParams,
+				valueJSON;
 
-			// If the control doesn't exist then return.
-			if ( _.isUndefined( subControl ) ) {
+			// If the control and control params don't exist then return.
+			if ( _.isUndefined( control ) && _.isUndefined( control.params ) ) {
 				return true;
 			}
+
+			controlParams = control.params;
 
 			// First set the value in the wp object. The control type doesn't matter here.
 			$this.setValue( setting, value );
 
 			// Process visually changing the value based on the control type.
-			switch ( subControl.type ) {
+			switch ( controlParams.type ) {
 
 				case 'kirki-background':
 					if ( ! _.isUndefined( value['background-color'] ) ) {
@@ -72,10 +75,10 @@ if ( _.isUndefined( window.kirkiSetSettingValue ) ) {
 					break;
 
 				case 'kirki-generic':
-					if ( _.isUndefined( subControl.choices ) || _.isUndefined( subControl.choices.element ) ) {
-						subControl.choices.element = 'input';
+					if ( _.isUndefined( controlParams.choices ) || _.isUndefined( controlParams.choices.element ) ) {
+						controlParams.choices.element = 'input';
 					}
-					jQuery( $this.findElement( setting, subControl.choices.element ) ).prop( 'value', value );
+					jQuery( $this.findElement( setting, controlParams.choices.element ) ).prop( 'value', value );
 					break;
 
 				case 'kirki-color':
@@ -141,7 +144,12 @@ if ( _.isUndefined( window.kirkiSetSettingValue ) ) {
 					// Do nothing.
 					break;
 				default:
-					jQuery( $this.findElement( setting, 'input' ) ).prop( 'value', value );
+					// If control provides reset fallback, call it
+					if ( ! _.isUndefined( control.onKirkiSetSettingValue ) && _.isFunction( control.onKirkiSetSettingValue ) ) {
+						control.onKirkiSetSettingValue( value );
+					} else {
+						jQuery( $this.findElement( setting, 'input' ) ).prop( 'value', value );
+					}
 			}
 		},
 


### PR DESCRIPTION
I'm having a problem where the reset button is resetting all inputs of my custom control, which is basically a group of checkboxes similar to "radio-image" field. This is the fallback behavior of the reset function (which as you're aware, behaves differently for each field type). The ideal solution for me would be for it to default for a reset callback, like

```
default:
    if ( ! _.isUndefined( onKirkiReset ) && _.isFunction( onKirkiReset ) ) {
      onKirkiReset(value)
    } else {
      jQuery( $this.findElement( setting, 'input' ) ).prop( 'value', value );
    }
```
or something like this. 
Instead, an easier solution for now is to only reset inputs with the controls `link` attribute. That way one could rely on the onChange event of such input.

Let me know your opinion

**EDIT:**
Tweaked it a little and I managed to achieve what I've proposed. It was easier than I was expecting. I also took the liberty to rename "subControl"  to "controlParams", to be honest I didn't get why they were called subControl, and I thought that since I needed to add a control var there, it would kinda clash and get a bit unreadable.

**EDIT2**: Though I do think that the fallback should still only search for "linked" inputs when nno callback function is provided..
```jQuery( $this.findElement( setting, '[' + controlParams.link + ']' ) ).prop( 'value', value );```