### PR TITLE
make sure value is a string before js replace()

### DIFF
--- a/controls/php/class-kirki-control-dimensions.php
+++ b/controls/php/class-kirki-control-dimensions.php
@@ -92,7 +92,7 @@ class Kirki_Control_Dimensions extends Kirki_Control_Base {
 								<# } #>
 							</h5>
 							<div class="{{ choiceKey }} input-wrapper">
-								<# var val = ( ! _.isUndefined( data.value ) && ! _.isUndefined( data.value[ choiceKey ] ) ) ? data.value[ choiceKey ].replace( '%%', '%' ) : ''; #>
+								<# var val = ( ! _.isUndefined( data.value ) && ! _.isUndefined( data.value[ choiceKey ] ) ) ? data.value[ choiceKey ].toString().replace( '%%', '%' ) : ''; #>
 								<input {{{ data.inputAttrs }}} type="text" data-choice="{{ choiceKey }}" value="{{ val }}"/>
 							</div>
 						</div>


### PR DESCRIPTION
Having an integer value will cause a fatal js error on the panel when using the dimensions control. This pull request fixes that. Related to https://github.com/aristath/kirki/issues/1578