### PR TITLE
Add preconnect for Google Fonts

### DIFF
--- a/modules/webfonts/class-kirki-modules-webfonts-async.php
+++ b/modules/webfonts/class-kirki-modules-webfonts-async.php
@@ -58,7 +58,32 @@ final class Kirki_Modules_Webfonts_Async {
 		$this->webfonts    = $webfonts;
 		$this->googlefonts = $googlefonts;
 
-		add_action( 'wp_head', array( $this, 'webfont_loader' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'webfont_loader' ) );
+
+		add_filter( 'wp_resource_hints', array( $this, 'resource_hints' ), 10, 2 );
+
+	}
+
+	/**
+	 * Add preconnect for Google Fonts.
+	 *
+	 * @access public
+	 * @param array  $urls           URLs to print for resource hints.
+	 * @param string $relation_type  The relation type the URLs are printed.
+	 * @return array $urls           URLs to print for resource hints.
+	 */
+	public function resource_hints( $urls, $relation_type ) {
+
+		$fonts_to_load = $this->googlefonts->fonts;
+
+		if ( ! empty( $fonts_to_load ) && 'preconnect' === $relation_type ) {
+			$urls[] = array(
+				'href' => 'https://fonts.gstatic.com',
+				'crossorigin',
+			);
+		}
+		return $urls;
+
 	}
 
 	/**


### PR DESCRIPTION
- Enqueue script/style under `wp_head` will load it under `wp_footer` which is give annoying FOUT. Unless we print the script asynchronously.
- Add preconnect for Google Fonts.