### PR TITLE
Fixes #1730

### DIFF
--- a/modules/field-dependencies/field-dependencies.js
+++ b/modules/field-dependencies/field-dependencies.js
@@ -138,7 +138,7 @@ var kirkiDependencies = {
 				} );
 				return found;
 			} else if ( _.isString( value2 ) ) {
-				return -1 < value1.indexOf( value2 );
+				return -1 < value2.indexOf( value1 );
 			}
 		}
 		if ( null === result ) {


### PR DESCRIPTION
@aristath - In my opinion #1515 breaks the "contains" operator's objective. My PR revert code to original to the extent to which context is string. After the fix code works like in the old documentation. Before my fix, code works inversely (code checking if value contains context instead checking if context contains value).

"contains, in : If the context is an array then we'll check if the value defined exists in the array (using PHP's in_array() function. **If on the other hand the context is a string then we'll check if the string contains the value** defined using PHP's strpos() and checking not the position of the string but whether the result returns false or not (using === for safety)."

