### PR TITLE
Include button_label in repeater docs

### DIFF
--- a/docs/docs/controls/repeater.md
+++ b/docs/docs/controls/repeater.md
@@ -31,8 +31,9 @@ Kirki::add_field( 'theme_config_id', array(
 		'type' => 'text',
 		'value' => esc_attr__('your custom value', 'textdomain' ),
 	),
-	'settings'    => 'my_setting',
-	'default'     => array(
+	'button_label' => esc_attr__('"Add new" button label (optional) ', 'textdomain' ),
+	'settings'     => 'my_setting',
+	'default'      => array(
 		array(
 			'link_text' => esc_attr__( 'Kirki Site', 'textdomain' ),
 			'link_url'  => 'https://aristath.github.io/kirki/',
@@ -72,8 +73,9 @@ Kirki::add_field( 'theme_config_id', array(
 		'value' => esc_attr__('your custom value', 'textdomain' ),
 		'field' => 'link_text',
 	),
-	'settings'    => 'my_setting',
-	'default'     => array(
+	'button_label' => esc_attr__('"Add new" button label (optional) ', 'textdomain' ),
+	'settings'     => 'my_setting',
+	'default'      => array(
 		array(
 			'link_text' => esc_attr__( 'Kirki Site', 'textdomain' ),
 			'link_url'  => 'https://aristath.github.io/kirki/',


### PR DESCRIPTION
Just include button_label attribute in repeater examples.