### PR TITLE
Add a preset argument for controls.

### DIFF
--- a/controls/php/class-kirki-control-base.php
+++ b/controls/php/class-kirki-control-base.php
@@ -58,6 +58,15 @@ class Kirki_Control_Base extends WP_Customize_Control {
 	public $required = array();
 
 	/**
+	 * Whitelisting the "preset" argument.
+	 *
+	 * @since 3.0.26
+	 * @access public
+	 * @var array
+	 */
+	public $preset = array();
+
+	/**
 	 * Extra script dependencies.
 	 *
 	 * @since 3.1.0
@@ -171,6 +180,8 @@ class Kirki_Control_Base extends WP_Customize_Control {
 		$this->json['kirkiOptionType'] = $this->option_type;
 		// The option-name.
 		$this->json['kirkiOptionName'] = $this->option_name;
+		// The preset.
+		$this->json['preset'] = $this->preset;
 	}
 
 	/**

--- a/core/class-kirki-modules.php
+++ b/core/class-kirki-modules.php
@@ -70,6 +70,7 @@ class Kirki_Modules {
 				'custom-sections'    => 'Kirki_Modules_Custom_Sections',
 				'webfonts'           => 'Kirki_Modules_Webfonts',
 				'webfont-loader'     => 'Kirki_Modules_Webfont_Loader',
+				'preset'             => 'Kirki_Modules_Preset',
 			)
 		);
 

--- a/modules/preset/class-kirki-modules-preset.php
+++ b/modules/preset/class-kirki-modules-preset.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Automatic preset scripts calculation for Kirki controls.
+ *
+ * @package     Kirki
+ * @category    Modules
+ * @author      Aristeides Stathopoulos
+ * @copyright   Copyright (c) 2017, Aristeides Stathopoulos
+ * @license     http://opensource.org/licenses/https://opensource.org/licenses/MIT
+ * @since       3.0.26
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds styles to the customizer.
+ */
+class Kirki_Modules_Preset {
+
+	/**
+	 * The object instance.
+	 *
+	 * @static
+	 * @access private
+	 * @since 3.0.26
+	 * @var object
+	 */
+	private static $instance;
+
+	/**
+	 * Constructor.
+	 *
+	 * @access protected
+	 * @since 3.0.26
+	 */
+	protected function __construct() {
+		add_action( 'customize_controls_print_footer_scripts', array( $this, 'customize_controls_print_footer_scripts' ) );
+	}
+
+	/**
+	 * Gets an instance of this object.
+	 * Prevents duplicate instances which avoid artefacts and improves performance.
+	 *
+	 * @static
+	 * @access public
+	 * @since 3.0.26
+	 * @return object
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Enqueue scripts.
+	 *
+	 * @access public
+	 * @since 3.0.26
+	 */
+	public function customize_controls_print_footer_scripts() {
+		wp_enqueue_script( 'kirki-preset', trailingslashit( Kirki::$url ) . 'modules/preset/preset.js', array( 'jquery' ), KIRKI_VERSION );
+	}
+}

--- a/modules/preset/preset.js
+++ b/modules/preset/preset.js
@@ -1,0 +1,32 @@
+/* global kirkiSetSettingValue */
+jQuery( document ).ready( function() {
+
+	// Loop Controls.
+	wp.customize.control.each( function( control ) {
+
+		// Check if we have a preset defined.
+		if ( control.params && control.params.preset && ! _.isEmpty( control.params.preset ) ) {
+			wp.customize( control.id, function( value ) {
+
+				// Listen to value changes.
+				value.bind( function( to ) {
+
+					// Loop preset definitions.
+					_.each( control.params.preset, function( preset, valueToListen ) {
+
+						// Check if the value set want is the same as the one we're looking for.
+						if ( valueToListen === to ) {
+
+							// Loop settings defined inside the preset.
+							_.each( preset.settings, function( controlValue, controlID ) {
+
+								// Set the value.
+								kirkiSetSettingValue.set( controlID, controlValue );
+							} );
+						}
+					} );
+				} );
+			} );
+		}
+	} );
+} );


### PR DESCRIPTION
This adds a `preset` argument to controls.

Example of the syntax used:
```php
Kirki::add_field( 'my_theme', array(
	'type'        => 'radio-image',
	'settings'    => 'radio_image_setting',
	'label'       => esc_attr__( 'Radio-Image Control', 'kirki' ),
	'description' => esc_attr__( 'The description here.', 'kirki' ),
	'section'     => 'radio_image_section',
	'default'     => 'travel',
	'choices'     => array(
		'moto'    => 'https://jawordpressorg.github.io/wapuu/wapuu-archive/wapuu-moto.png',
		'cossack' => 'https://raw.githubusercontent.com/templatemonster/cossack-wapuula/master/cossack-wapuula.png',
		'travel'  => 'https://jawordpressorg.github.io/wapuu/wapuu-archive/wapuu-travel.png',
	),
	'preset'      => array(
		'moto'    => array(
			'settings' => array(
				'radio_buttonset_setting' => 'option-1',
				'radio_setting'           => 'option-2',
			),
		),
		'cossack' => array(
			'settings' => array(
				'radio_buttonset_setting' => 'option-2',
				'radio_setting'           => 'option-1',
			),
		),
		'travel'  => array(
			'settings' => array(
				'radio_buttonset_setting' => 'option-3',
				'radio_setting'           => 'option-3',
			),
		),
	),
) );
```
