### PR TITLE
#1914 passes required envato check for is_plugin_active

### DIFF
--- a/core/class-kirki-util.php
+++ b/core/class-kirki-util.php
@@ -60,7 +60,7 @@ class Kirki_Util {
 		include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		// Extra logic in case the plugin is installed but not activated.
-		if ( $_plugin && ! is_plugin_active( $_plugin ) ) {
+		if ( $_plugin && is_plugin_inactive( $_plugin ) ) {
 			return false;
 		}
 		return $is_plugin;


### PR DESCRIPTION
![is-plugin-active-kirki](https://user-images.githubusercontent.com/11907254/41478846-304c5258-7097-11e8-8c7b-2a3c4e94ea13.png)

Uses core method which passes envato's theme checker.  Functionally [it's the same](https://core.trac.wordpress.org/browser/tags/4.9/src/wp-admin/includes/plugin.php#L473).
