### PR TITLE
Duplicate array key height

### DIFF
--- a/controls/php/class-kirki-control-dimensions.php
+++ b/controls/php/class-kirki-control-dimensions.php
@@ -133,7 +133,6 @@ class Kirki_Control_Dimensions extends Kirki_Control_Base {
 			'right'          => esc_attr__( 'Right', 'kirki' ),
 			'center'         => esc_attr__( 'Center', 'kirki' ),
 			'size'           => esc_attr__( 'Size', 'kirki' ),
-			'height'         => esc_attr__( 'Height', 'kirki' ),
 			'spacing'        => esc_attr__( 'Spacing', 'kirki' ),
 			'width'          => esc_attr__( 'Width', 'kirki' ),
 			'height'         => esc_attr__( 'Height', 'kirki' ),


### PR DESCRIPTION
If multiple elements in the array declaration use the same key, only the last one will be used as all others are overwritten.