### PR TITLE
PHPCS: Use PHPCompatibilityWP and use it correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - eslint ./modules/**/*.js
   # WordPress Coding Standards.
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+  # @link https://github.com/PHPCompatibility/PHPCompatibilityWP
   # @link http://pear.php.net/package/PHP_CodeSniffer/
   # -p flag: Show progress of the run.
   # -s flag: Show sniff codes in all reports.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "phpunit/phpunit": "*",
     "composer/installers": "*",
     "dealerdirect/phpcodesniffer-composer-installer": "*",
-    "wimg/php-compatibility": "*",
+    "phpcompatibility/phpcompatibility-wp": "*",
     "wp-coding-standards/wpcs": "*",
     "codacy/coverage": "dev-master"
   }

--- a/core/class-kirki-helper.php
+++ b/core/class-kirki-helper.php
@@ -31,8 +31,7 @@ class Kirki_Helper {
 	 */
 	public static function array_replace_recursive( $array, $array1 ) {
 		if ( function_exists( 'array_replace_recursive' ) ) {
-			// @codingStandardsIgnoreLine PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
-			return array_replace_recursive( $array, $array1 ); // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
+			return array_replace_recursive( $array, $array1 );
 		}
 
 		// Handle the arguments, merge one by one.

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -15,5 +15,7 @@
 	</rule>
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
-	<rule ref="PHPCompatibility"/>
+	<!-- See: https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibilityWP"/>
 </ruleset>


### PR DESCRIPTION
This PR:
* Switches the repo over to use `PHPCompatibilityWP` rather than `PHPCompatibility`.
    As this repo and ruleset is aimed at a WordPress project, using the `PHPCompatibilityWP` ruleset is the better choice to prevent false positives for PHP functions and constants which are back-filled by WP.
* Switches the dependency over to use the repo in the `PHPCompatibility` GitHub organisation rather than the one in `wimg`'s personal account.
* Removes a PHPCS annotation to suppress a notice about a back-filled function, which is no longer needed.
* Adds a `testVersion` config directive to the PHPCS ruleset to tell PHPCompatibility with which PHP versions the code should be compatible.
    Without this directive, PHPCompatibility only throws errors/warnings about deprecated/removed PHP features. Not about the use of new features not supported in older PHP versions.
    Adding the directive fixes this.
* Add relevant links to the inline documentation of the Travis script and the ruleset.

### References:
* https://github.com/PHPCompatibility/PHPCompatibilityWP
* https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
* https://github.com/PHPCompatibility/PHPCompatibility/issues/688
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0