### PR TITLE
Improve CSS vars rendering

### DIFF
--- a/modules/css-vars/class-kirki-modules-css-vars.php
+++ b/modules/css-vars/class-kirki-modules-css-vars.php
@@ -43,7 +43,7 @@ class Kirki_Modules_CSS_Vars {
 	 * @since 3.0.28
 	 */
 	protected function __construct() {
-		add_action( 'wp_head', array( $this, 'the_style' ), 0 );
+		add_action( 'wp_head', array( $this, 'the_style' ) );
 		add_action( 'customize_preview_init', array( $this, 'postmessage' ) );
 	}
 


### PR DESCRIPTION
CSS vars may already defined (and used) in theme's css files.
The CSS vars from Kirki should have more high priority (aka, later rendering) than theme's css files (in the same way as kirki-styles-css).