### PR TITLE
Fix css vars rendering

### DIFF
--- a/modules/css-vars/class-kirki-modules-css-vars.php
+++ b/modules/css-vars/class-kirki-modules-css-vars.php
@@ -83,11 +83,13 @@ class Kirki_Modules_CSS_Vars {
 				continue;
 			}
 			$val = Kirki_Values::get_value( $args['kirki_config'], $id );
-			foreach ( $args['css_vars'] as $css_var ) {
-				if ( isset( $css_var[2] ) && is_array( $val ) && isset( $val[ $css_var[2] ] ) ) {
-					echo esc_html( $css_var[0] ) . ':' . esc_html( str_replace( '$', $val[ $css_var[2] ], $css_var[1] ) ) . ';';
-				} else {
-					echo esc_html( $css_var[0] ) . ':' . esc_html( str_replace( '$', $val, $css_var[1] ) ) . ';';
+			if ( ! empty( $val ) ) {
+				foreach ( $args['css_vars'] as $css_var ) {
+					if ( isset( $css_var[2] ) && is_array( $val ) && isset( $val[ $css_var[2] ] ) ) {
+						echo esc_html( $css_var[0] ) . ':' . esc_html( str_replace( '$', $val[ $css_var[2] ], $css_var[1] ) ) . ';';
+					} else {
+						echo esc_html( $css_var[0] ) . ':' . esc_html( str_replace( '$', $val, $css_var[1] ) ) . ';';
+					}
 				}
 			}
 		}

--- a/modules/css-vars/class-kirki-modules-css-vars.php
+++ b/modules/css-vars/class-kirki-modules-css-vars.php
@@ -43,8 +43,9 @@ class Kirki_Modules_CSS_Vars {
 	 * @since 3.0.28
 	 */
 	protected function __construct() {
-		add_action( 'wp_head', array( $this, 'the_style' ), 0 );
-		add_action( 'admin_head', array( $this, 'the_style' ), 0 );
+		$priority = 999;
+		add_action( 'wp_head', array( $this, 'the_style' ), $priority );
+		add_action( 'admin_head', array( $this, 'the_style' ), $priority );
 		add_action( 'customize_preview_init', array( $this, 'postmessage' ) );
 	}
 

--- a/modules/css-vars/class-kirki-modules-css-vars.php
+++ b/modules/css-vars/class-kirki-modules-css-vars.php
@@ -37,15 +37,24 @@ class Kirki_Modules_CSS_Vars {
 	private $fields = array();
 
 	/**
+	 * CSS-variables array [var=>val].
+	 *
+	 * @access private
+	 * @since 3.0.35
+	 * @var array
+	 */
+	private $vars = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @access protected
 	 * @since 3.0.28
 	 */
 	protected function __construct() {
-		$priority = 999;
-		add_action( 'wp_head', array( $this, 'the_style' ), $priority );
-		add_action( 'admin_head', array( $this, 'the_style' ), $priority );
+		add_action( 'wp', array( $this, 'populate_vars' ) );
+		add_action( 'wp_head', array( $this, 'the_style' ), 999 );
+		add_action( 'admin_head', array( $this, 'the_style' ), 999 );
 		add_action( 'customize_preview_init', array( $this, 'postmessage' ) );
 	}
 
@@ -66,6 +75,32 @@ class Kirki_Modules_CSS_Vars {
 	}
 
 	/**
+	 * Populates the $vars property of this object.
+	 *
+	 * @access public
+	 * @since 3.0.35
+	 * @return void
+	 */
+	public function populate_vars() {
+
+		// Get an array of all fields.
+		$fields = Kirki::$fields;
+		foreach ( $fields as $id => $args ) {
+			if ( ! isset( $args['css_vars'] ) || empty( $args['css_vars'] ) ) {
+				continue;
+			}
+			$val = Kirki_Values::get_value( $args['kirki_config'], $id );
+			foreach ( $args['css_vars'] as $css_var ) {
+				if ( isset( $css_var[2] ) && is_array( $val ) && isset( $val[ $css_var[2] ] ) ) {
+					$this->vars[ $css_var[0] ] = str_replace( '$', $val[ $css_var[2] ], $css_var[1] );
+				} else {
+					$this->vars[ $css_var[0] ] = str_replace( '$', $val, $css_var[1] );
+				}
+			}
+		}
+	}
+
+	/**
 	 * Add styles in <head>.
 	 *
 	 * @access public
@@ -74,27 +109,28 @@ class Kirki_Modules_CSS_Vars {
 	 */
 	public function the_style() {
 
-		// Get an array of all fields.
-		$fields = Kirki::$fields;
+		if ( empty( $this->vars ) ) {
+			return;
+		}
+
 		echo '<style id="kirki-css-vars">';
 		echo ':root{';
-		foreach ( $fields as $id => $args ) {
-			if ( ! isset( $args['css_vars'] ) || empty( $args['css_vars'] ) ) {
-				continue;
-			}
-			$val = Kirki_Values::get_value( $args['kirki_config'], $id );
-			if ( ! empty( $val ) ) {
-				foreach ( $args['css_vars'] as $css_var ) {
-					if ( isset( $css_var[2] ) && is_array( $val ) && isset( $val[ $css_var[2] ] ) ) {
-						echo esc_html( $css_var[0] ) . ':' . esc_html( str_replace( '$', $val[ $css_var[2] ], $css_var[1] ) ) . ';';
-					} else {
-						echo esc_html( $css_var[0] ) . ':' . esc_html( str_replace( '$', $val, $css_var[1] ) ) . ';';
-					}
-				}
-			}
+		foreach ( $this->vars as $var => $val ) {
+			echo esc_html( $var ) . ':' . esc_html( $val ) . ';';
 		}
 		echo '}';
 		echo '</style>';
+	}
+
+	/**
+	 * Get an array of all the variables.
+	 *
+	 * @access public
+	 * @since 3.0.35
+	 * @return array
+	 */
+	public function get_vars() {
+		return $this->vars;
 	}
 
 	/**


### PR DESCRIPTION
This PR contains 2 fixes.

**Css vars from kiki must override the existing css vars from theme**
Since the inline css output from Kiki has pririty is 999 (after theme's style), The css vars is an inline css too and it should be rendered after theme's style.

This will allow theme author can define their own css vars for usage as a default (when user leave customizer settings as a default value and no css vars rendered).


**Do not render css vars when empty value**
An empty value of css vars is caused of css parsing error and will not pass the HTML5 validation of https://validator.w3.org/nu/

Just add an if condition for checking an empty value before rendering.