### PR TITLE
Fixed check context for dynamic stylesheet

### DIFF
--- a/modules/css/class-kirki-modules-css.php
+++ b/modules/css/class-kirki-modules-css.php
@@ -143,11 +143,10 @@ class Kirki_Modules_CSS {
 		// Enqueue the dynamic stylesheet.
 		wp_enqueue_style(
 			'kirki-styles',
-			add_query_arg(
-				'action',
-				apply_filters( 'kirki_styles_action_handle', 'kirki-styles' ),
-				site_url()
-			),
+			add_query_arg( array(
+				'action' => apply_filters( 'kirki_styles_action_handle', 'kirki-styles' ),
+				'editor' => ( is_admin() && ! is_customize_preview() ),
+			), site_url() ),
 			array(),
 			KIRKI_VERSION
 		);

--- a/modules/css/class-kirki-output.php
+++ b/modules/css/class-kirki-output.php
@@ -243,7 +243,7 @@ class Kirki_Output {
 
 			$value = $this->process_value( $value, $output );
 
-			if ( is_admin() && ! is_customize_preview() ) {
+			if ( ( is_admin() && ! is_customize_preview() ) || ( isset( $_GET['editor'] ) && $_GET['editor'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 
 				// Check if this is an admin style.
 				if ( ! isset( $output['context'] ) || ! in_array( 'editor', $output['context'], true ) ) {


### PR DESCRIPTION
Styles in the editor enqueue via hook
`add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_styles' ), 100 );`

The problem is that the context check does not work in /?action=kirki-styles