### PR TITLE
Update class-kirki-fonts-google.php

### DIFF
--- a/modules/webfonts/class-kirki-fonts-google.php
+++ b/modules/webfonts/class-kirki-fonts-google.php
@@ -213,7 +213,7 @@ final class Kirki_Fonts_Google {
 
 				// If this is not a valid variant for this font-family
 				// then unset it and move on to the next one.
-				if ( ! in_array( $variant, $font_variants, true ) ) {
+				if ( ! in_array( strval($variant), $font_variants, true ) ) {
 					$variant_key = array_search( $variant, $this->fonts[ $font ], true );
 					unset( $this->fonts[ $font ][ $variant_key ] );
 					continue;

--- a/modules/webfonts/class-kirki-fonts-google.php
+++ b/modules/webfonts/class-kirki-fonts-google.php
@@ -213,7 +213,7 @@ final class Kirki_Fonts_Google {
 
 				// If this is not a valid variant for this font-family
 				// then unset it and move on to the next one.
-				if ( ! in_array( strval($variant), $font_variants, true ) ) {
+				if ( ! in_array( strval( $variant ), $font_variants, true ) ) {
 					$variant_key = array_search( $variant, $this->fonts[ $font ], true );
 					unset( $this->fonts[ $font ][ $variant_key ] );
 					continue;


### PR DESCRIPTION
Process Google fonts function does not worked correctly. Fonts variants was not loaded correctly because of this issue with different variables (string and integer) comparison in array (some correct fonts variants like 100,200,300, bolds, etc was skipped and not loaded to site if "load all font variants" feature was enabled). 
For example if Google Font have 100,100italic,200,200italic variants - function remove 100 and 200 from variants. Now this is fixed.
Can be related only to some (PHP7+) PHP versions.
