### PR TITLE
Add SCSS support

### DIFF
--- a/field/class-kirki-field-code.php
+++ b/field/class-kirki-field-code.php
@@ -96,6 +96,17 @@ class Kirki_Field_Code extends Kirki_Field {
 		if ( ! isset( $this->editor_settings['codemirror']['mode'] ) ) {
 			$this->editor_settings['codemirror']['mode'] = $language;
 		}
+		
+		if($this->editor_settings['codemirror']['mode'] === 'text/x-scss') {
+  			$this->editor_settings['codemirror'] = array_merge(
+				$this->editor_settings['codemirror'],
+				array(
+					'lint'              => false,
+					'autoCloseBrackets' => true,
+					'matchBrackets'     => true,
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The CSS linter for SCSS does not work but unfortunatelly the linter is enabled, even id "scss" is provided as language. So I added the corresponding editor settings to disable linting if the code field has the type "text/x-scss".

WP does it the same way: https://developer.wordpress.org/reference/functions/wp_get_code_editor_settings/