### PR TITLE
Fixed download fonts

### DIFF
--- a/modules/webfonts/class-kirki-fonts-helper.php
+++ b/modules/webfonts/class-kirki-fonts-helper.php
@@ -118,6 +118,7 @@ final class Kirki_Fonts_Helper {
 		);
 
 		$overrides = array(
+			'test_type' => false,
 			'test_form' => false,
 			'test_size' => true,
 		);

--- a/modules/webfonts/class-kirki-modules-webfonts-embed.php
+++ b/modules/webfonts/class-kirki-modules-webfonts-embed.php
@@ -222,7 +222,10 @@ final class Kirki_Modules_Webfonts_Embed {
 	 * @return string     The CSS with local URLs.
 	 */
 	private function use_local_files( $css ) {
-		preg_match( '/https\:.*?\.woff/', $css, $matches );
+		preg_match_all( '/https\:.*?\.woff/', $css, $matches );
+
+		$matches = array_shift( $matches );
+
 		foreach ( $matches as $match ) {
 			if ( 0 === strpos( $match, 'https://fonts.gstatic.com' ) ) {
 				$new_url = Kirki_Fonts_Helper::download_font_file( $match );


### PR DESCRIPTION
1. Fixed a problem in the use_local_files function, parsing only one link from the code.

2. Function wp_handle_sideload check MIME type for uploaded files (Error - Sorry, this file type is not permitted for security reasons). I propose how to add the solution `'test_type' => false`