### PR TITLE
Remove Duplicate License URL

### DIFF
--- a/vendor/kirki-framework/core/src/Telemetry.php
+++ b/vendor/kirki-framework/core/src/Telemetry.php
@@ -6,7 +6,7 @@
  * @category    Core
  * @author      Ari Stathopoulos (@aristath)
  * @copyright   Copyright (c) 2019, Ari Stathopoulos (@aristath)
- * @license     http://opensource.org/licenses/https://opensource.org/licenses/MIT
+ * @license     https://opensource.org/licenses/MIT
  * @since       3.0.36
  */
 


### PR DESCRIPTION
Hi there! 👋 
Hope you are doing well! ❤️ 

This is rather a very simple pull request. I was just roaming around in the code and found a duplicate license URL in the telemetry implementation file. This PR just simply removes that.

Thank you ❤️ 