### PR TITLE
Improve consistency of naming and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kirki #
-**Contributors:** [aristath](https://profiles.wordpress.org/aristath), [wplemon](https://profiles.wordpress.org/wplemon), [igmoweb](https://profiles.wordpress.org/igmoweb)  
-**Tags:** customizer,options framework, theme, mods, toolkit, gutenberg  
-**Donate link:** https://aristath.github.io/donate  
-**Requires at least:** 4.9  
-**Tested up to:** 5.2  
-**Stable tag:** 3.0.40  
-**License:** MIT  
-**License URI:** https://opensource.org/licenses/MIT  
+**Contributors:** [aristath](https://profiles.wordpress.org/aristath), [wplemon](https://profiles.wordpress.org/wplemon), [igmoweb](https://profiles.wordpress.org/igmoweb)
+**Tags:** customizer,options framework, theme, mods, toolkit, gutenberg
+**Donate link:** https://aristath.github.io/donate
+**Requires at least:** 4.9
+**Tested up to:** 5.2
+**Stable tag:** 3.0.40
+**License:** MIT
+**License URI:** https://opensource.org/licenses/MIT
 
 The ultimate framework for theme developers using the WordPress Customizer
 
@@ -28,7 +28,7 @@ Premium controls are also available for premium themes:
 
 Theme developers should be familiar with the Customizer API before you start writing your theme using Kirki. An excellent handbook for the WordPress Customizer can be found on the [developer.wordpress.org](https://developer.wordpress.org/themes/customize-api/) website.
 
-You can find detailed documentation on how to use Kirki on [aristath.github.io/kirki/](https://aristath.github.io/kirki/)
+You can find detailed documentation on how to use Kirki on [kirki.org](https://kirki.org)
 
 [Development and issues on github](https://github.com/aristath/kirki).
 
@@ -36,7 +36,7 @@ You can find detailed documentation on how to use Kirki on [aristath.github.io/k
 
 Simply install as a normal WordPress plugin and activate.
 
-If you want to integrate Kirki in your theme or plugin, please read the instructions on [our documentation site](https://aristath.github.io/kirki/docs/integration).
+If you want to integrate Kirki in your theme or plugin, please read the instructions on [our documentation site](https://kirki.org/docs/integration).
 
 ## Changelog ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kirki #
-**Contributors:** [aristath](https://profiles.wordpress.org/aristath), [wplemon](https://profiles.wordpress.org/wplemon), [igmoweb](https://profiles.wordpress.org/igmoweb)
-**Tags:** customizer,options framework, theme, mods, toolkit, gutenberg
+**Contributors:** [aristath](https://profiles.wordpress.org/aristath), [dannycooper](https://profiles.wordpress.org/dannycooper), [wplemon](https://profiles.wordpress.org/wplemon), [igmoweb](https://profiles.wordpress.org/igmoweb)
+**Tags:** customizer, options framework, theme, mods, toolkit, gutenberg
 **Donate link:** https://aristath.github.io/donate
 **Requires at least:** 4.9
 **Tested up to:** 5.2
@@ -30,7 +30,7 @@ Theme developers should be familiar with the Customizer API before you start wri
 
 You can find detailed documentation on how to use Kirki on [kirki.org](https://kirki.org)
 
-[Development and issues on github](https://github.com/aristath/kirki).
+[Development and issues on GitHub](https://github.com/aristath/kirki).
 
 ## Installation ##
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kirki #
+# Kirki Customizer Framework #
 **Contributors:** [aristath](https://profiles.wordpress.org/aristath), [dannycooper](https://profiles.wordpress.org/dannycooper), [wplemon](https://profiles.wordpress.org/wplemon), [igmoweb](https://profiles.wordpress.org/igmoweb)
 **Tags:** customizer, options framework, theme, mods, toolkit, gutenberg
 **Donate link:** https://aristath.github.io/donate

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,13 +30,13 @@ script: testimonials-script.html
             </div>
             <div class="feature cell medium-6">
                 <h3>Controls</h3>
-                <p>With 30 custom controls and counting at your disposal, chances are Kirki has what you need. <a href="https://aristath.github.io/kirki/docs/controls/">Take a look at what's available</a></p>
+                <p>With 30 custom controls and counting at your disposal, chances are Kirki has what you need. <a href="https://kirki.org/docs/controls/">Take a look at what's available</a></p>
             </div>
         </div>
         <div class="grid-x grid-margin-x features">
             <div class="feature cell medium-6">
                 <h3>Clean Code</h3>
-                <p>Kirki's codebase is 100% compliant with WordPress Coding Standards and we continiously improve the quality of our code for performance and security.</p>
+                <p>Kirki's codebase is 100% compliant with WordPress Coding Standards and we continuously improve the quality of our code for performance and security.</p>
             </div>
             <div class="feature cell medium-6">
                 <h3>More features</h3>

--- a/example.php
+++ b/example.php
@@ -6,7 +6,7 @@
  * @category    Core
  * @author      Ari Stathopoulos (@aristath)
  * @copyright   Copyright (c) 2019, Ari Stathopoulos (@aristath)
- * @license    https://opensource.org/licenses/MIT
+ * @license     https://opensource.org/licenses/MIT
  * @since       3.0.12
  */
 

--- a/kirki.php
+++ b/kirki.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Plugin Name:   Kirki Toolkit
- * Plugin URI:    http://aristath.github.io/kirki
+ * Plugin URI:    https://kirki.org
  * Description:   The ultimate WordPress Customizer Toolkit
  * Author:        Ari Stathopoulos (@aristath)
- * Author URI:    http://aristath.github.io
+ * Author URI:    https://aristath.github.io
  * Version:       3.0.40
  * Text Domain:   kirki
  * Requires WP:   4.9

--- a/kirki.php
+++ b/kirki.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name:   Kirki Toolkit
+ * Plugin Name:   Kirki Customizer Framework
  * Plugin URI:    https://kirki.org
- * Description:   The ultimate WordPress Customizer Toolkit
+ * Description:   The Ultimate WordPress Customizer Framework
  * Author:        Ari Stathopoulos (@aristath)
  * Author URI:    https://aristath.github.io
  * Version:       3.0.40

--- a/lib/class-kirki-color.php
+++ b/lib/class-kirki-color.php
@@ -7,7 +7,7 @@
  * @category    Core
  * @author      Ari Stathopoulos (@aristath)
  * @copyright   Copyright (c) 2019, Ari Stathopoulos (@aristath)
- * @license    https://opensource.org/licenses/MIT
+ * @license     https://opensource.org/licenses/MIT
  * @since       1.0
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Kirki ===
+=== Kirki Customizer Framework ===
 Contributors: aristath, wplemon, igmoweb, dannycooper
 Tags: customizer, options framework, theme, mods, toolkit, gutenberg
 Donate link: https://aristath.github.io/donate

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Kirki ===
 Contributors: aristath, wplemon, igmoweb, dannycooper
-Tags: customizer,options framework, theme, mods, toolkit, gutenberg
+Tags: customizer, options framework, theme, mods, toolkit, gutenberg
 Donate link: https://aristath.github.io/donate
 Requires at least: 4.9
 Tested up to: 5.2
@@ -28,7 +28,7 @@ Premium controls are also available for premium themes:
 
 Theme developers should be familiar with the Customizer API before you start writing your theme using Kirki. An excellent handbook for the WordPress Customizer can be found on the [developer.wordpress.org](https://developer.wordpress.org/themes/customize-api/) website.
 
-You can find detailed documentation on how to use Kirki on [aristath.github.io/kirki/](https://aristath.github.io/kirki/)
+You can find detailed documentation on how to use Kirki on [kirki.org](https://kirki.org)
 
 [Development and issues on github](https://github.com/aristath/kirki).
 
@@ -36,7 +36,7 @@ You can find detailed documentation on how to use Kirki on [aristath.github.io/k
 
 Simply install as a normal WordPress plugin and activate.
 
-If you want to integrate Kirki in your theme or plugin, please read the instructions on [our documentation site](https://aristath.github.io/kirki/docs/integration).
+If you want to integrate Kirki in your theme or plugin, please read the instructions on [our documentation site](https://kirki.org/docs/integration).
 
 == Changelog ==
 

--- a/upgrade-notifications.php
+++ b/upgrade-notifications.php
@@ -6,7 +6,7 @@
  * @category    Core
  * @author      Ari Stathopoulos (@aristath)
  * @copyright   Copyright (c) 2019, Ari Stathopoulos (@aristath)
- * @license    https://opensource.org/licenses/MIT
+ * @license     https://opensource.org/licenses/MIT
  * @since       3.0.0
  */
 


### PR DESCRIPTION
Make the plugin easier to find on WordPress.org for "Customizer" related searches through consistent naming.

Also add dannycooper to contributors and fix small alignment issues.