### PR TITLE
Footer: Update link to page edition

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -11,7 +11,7 @@
 		<!-- UNDER CONSTRUCTION WARNING -->
 		{% if page.skipWrapper %}<div id="main-warning" class="grid-container grid-margin-x">{% endif %}
 		<div class="callout primary ribbon-full" style="text-align: center;">
-			<p>Can't find what you're looking for? Check the <a href="https://github.com/aristath/kirki/issues">github issues</a>{% if page.hideEditLink %}{% else %} or <a href="{{ site.repository }}/edit/develop/docs/{{ page.path }}">edit this page to add what's missing</a>{% endif %}.</p>
+			<p>Can't find what you're looking for? Check the <a href="https://github.com/aristath/kirki/issues">github issues</a>{% if page.hideEditLink %}{% else %} or <a href="{{ site.repository }}/edit/master/docs/{{ page.path }}">edit this page to add what's missing</a>{% endif %}.</p>
 		</div>
 		{% if page.skipWrapper %}</div>{% endif %}
 		<!-- END UNDER CONSTRUCTION WARNING -->


### PR DESCRIPTION
Currently, the link points to the develop branch that doesn't have a docs folder, resulting in a 404 error.