### PR TITLE
Removing deprecation notice for PHP 7.3 in Helper.php

### DIFF
--- a/packages/kirki-framework/util/src/Helper.php
+++ b/packages/kirki-framework/util/src/Helper.php
@@ -383,7 +383,7 @@ class Helper {
 			if ( is_array( $value2 ) && ! is_array( $value1 ) ) {
 				return in_array( $value1, $value2 ); // phpcs:ignore WordPress.PHP.StrictInArray
 			}
-			return ( false !== strrpos( $value1, $value2 ) || false !== strpos( $value2, $value1 ) );
+			return ( false !== strrpos( $value1, chr( $value2 ) ) || false !== strpos( $value2, chr( $value1 ) ) );
 		}
 		if ( 'does not contain' === $operator || 'not in' === $operator ) {
 			return ! self::compare_values( $value1, $value2, $operator );


### PR DESCRIPTION
As read in docs:
 
If needle is not a string, it is converted to an integer and applied as the ordinal value of a character. This behavior is deprecated as of PHP 7.3.0, and relying on it is highly discouraged. Depending on the intended behavior, the needle should either be explicitly cast to string, or an explicit call to chr() should be performed.