### PR TITLE
 Update class-kirki-modules.php to fix bedrock compat

### DIFF
--- a/modules/css/class-kirki-modules-css.php
+++ b/modules/css/class-kirki-modules-css.php
@@ -140,7 +140,7 @@ class Kirki_Modules_CSS {
 		// Enqueue the dynamic stylesheet.
 		wp_enqueue_style(
 			'kirki-styles',
-			add_query_arg( $args, site_url() ),
+			add_query_arg( $args, home_url() ),
 			array(),
 			KIRKI_VERSION
 		);


### PR DESCRIPTION
When using [Bedrock](https://roots.io/bedrock/) the WordPress folders are placed in a /wp/ folder. Using site_url() points to that /wp/ folder.
Since this is a hook that we want to call directly to the front-end we need to use home_url() instead.

This fixes the issuse where this hook causes a 404 in the backend:

![image](https://user-images.githubusercontent.com/17764157/107802283-6a715680-6d61-11eb-8f55-a6c738eaef3b.PNG)

Fixes: https://github.com/kirki-framework/kirki/issues/2365
