### PR TITLE
PHP 8.2 deprecation notices

### DIFF
--- a/kirki-packages/compatibility/src/Field.php
+++ b/kirki-packages/compatibility/src/Field.php
@@ -31,7 +31,7 @@ class Field {
 	public $button_label;
 	public $description;
 	public $help;
-	// public $compiler;
+	public $compiler;
 
 	protected $args = array();
 

--- a/kirki-packages/compatibility/src/Field.php
+++ b/kirki-packages/compatibility/src/Field.php
@@ -31,6 +31,7 @@ class Field {
 	public $button_label;
 	public $description;
 	public $help;
+	// public $compiler;
 
 	protected $args = array();
 


### PR DESCRIPTION
### Issue description:

Using PHP 8.2 Kirki causes a couple of [deprecation notices related to dynamic properties](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties).

### Version used:
5.0.0

### Using `theme_mods` or `options`?
`theme_mods`

### PHP error messages that might be related
```bash
Deprecated: Creation of dynamic property Kirki\Compatibility\Field::$compiler is deprecated in /Users/workspace/Servers/Themeforest/newsblock/wp-content/plugins/kirki/kirki-packages/compatibility/src/Field.php on line 307
```

### Code to reproduce the issue (config + field(s))
```php
add_action( 'customize_register', function( $wp_customize ) {
	if ( class_exists( 'Kirki_Control_Base' ) ) {
		/**
		 * The custom control class
		 */
		class Kirki_Collapsible extends Kirki_Control_Base {
			/**
			 * Control's Type.
			 *
			 * @since 3.4.0
			 * @var string
			 */
			public $type = 'collapsible';

			/**
			 * Renders the control content.
			 *
			 * @since 0.1
			 * @access protected
			 * @return void
			 */
			protected function render_content() {

				$collapsed_class = null;

				if ( isset( $this->input_attrs['collapsed'] ) && $this->input_attrs['collapsed'] ) {
					$collapsed_class = 'customize-collapsed';
				}
				?>
				<div class="customize-collapsible <?php echo esc_attr( $collapsed_class ); ?>"><h3><?php echo esc_attr( $this->label ); ?></h3></div>
				<?php
			}
		}

		// Register our custom control with Kirki.
		add_filter( 'kirki_control_types', function( $controls ) {
			$controls['collapsible'] = 'Kirki_Collapsible';
			return $controls;
		} );
	}
} );

Kirki::add_field(
	'csco_theme_mod',
	array(
		'type'        => 'collapsible',
		'settings'    => 'design_collapsible_common',
		'section'     => 'design',
		'label'       => esc_html__( 'Common', 'newsblock' ),
		'priority'    => 10,
		'input_attrs' => array(
			'collapsed' => true,
		),
	)
);

