### PR TITLE
Added apply_filters to subset so it can be overwritten if wanted

### DIFF
--- a/kirki-packages/module-webfonts/src/Webfonts/Async.php
+++ b/kirki-packages/module-webfonts/src/Webfonts/Async.php
@@ -125,6 +125,8 @@ final class Async {
 		// Goes through $this->fonts and adds or removes things as needed.
 		$this->googlefonts->process_fonts();
 
+		$subset = apply_filters( 'kirki_googlefonts_subset', 'cyrillic,cyrillic-ext,devanagari,greek,greek-ext,khmer,latin,latin-ext,vietnamese,hebrew,arabic,bengali,gujarati,tamil,telugu,thai' );
+
 		foreach ( $this->googlefonts->fonts as $font => $weights ) {
 			foreach ( $weights as $key => $value ) {
 				if ( 'italic' === $value ) {
@@ -133,7 +135,7 @@ final class Async {
 					$weights[ $key ] = str_replace( [ 'regular', 'bold', 'italic' ], [ '400', '', 'i' ], $value );
 				}
 			}
-			$this->fonts_to_load[] = $font . ':' . join( ',', $weights ) . ':cyrillic,cyrillic-ext,devanagari,greek,greek-ext,khmer,latin,latin-ext,vietnamese,hebrew,arabic,bengali,gujarati,tamil,telugu,thai';
+			$this->fonts_to_load[] = $font . ':' . join( ',', $weights ) . ':' . $subset;
 		}
 		if ( ! empty( $this->fonts_to_load ) ) {
 			self::$load = true;

--- a/kirki-packages/module-webfonts/src/Webfonts/Embed.php
+++ b/kirki-packages/module-webfonts/src/Webfonts/Embed.php
@@ -148,7 +148,8 @@ final class Embed {
 
 			$family  = str_replace( ' ', '+', trim( $font['family'] ) );
 			$weights = join( ',', $font['weights'] );
-			$url     = "https://fonts.googleapis.com/css?family={$family}:{$weights}&subset=cyrillic,cyrillic-ext,devanagari,greek,greek-ext,khmer,latin,latin-ext,vietnamese,hebrew,arabic,bengali,gujarati,tamil,telugu,thai&display=swap";
+			$subset  = apply_filters( 'kirki_googlefonts_subset', 'cyrillic,cyrillic-ext,devanagari,greek,greek-ext,khmer,latin,latin-ext,vietnamese,hebrew,arabic,bengali,gujarati,tamil,telugu,thai' );
+			$url     = "https://fonts.googleapis.com/css?family={$family}:{$weights}&subset={$subset}&display=swap";
 
 			$downloader = new Downloader();
 			$contents   = $downloader->get_styles( $url );


### PR DESCRIPTION
This pull request includes a change to the `kirki-packages/module-webfonts/src/Webfonts/Embed.php` file to make the Google Fonts subsets filterable. This allows for greater customization of font subsets through the use of the `kirki_googlefonts_subset` filter.