### PR TITLE
Add tab property declaration to Field class to resolve PHP 8.2 deprec…

### DIFF
--- a/kirki-packages/compatibility/src/Field.php
+++ b/kirki-packages/compatibility/src/Field.php
@@ -31,7 +31,6 @@ class Field {
 	public $button_label;
 	public $description;
 	public $help;
-	public $compiler;
 
 	protected $args = array();
 
@@ -136,6 +135,14 @@ class Field {
 	 * @var string
 	 */
 	protected $section = '';
+
+	/**
+	 * Assign this field to a tab within a section.
+	 *
+	 * @access protected
+	 * @var string
+	 */
+	protected $tab = '';
 
 	/**
 	 * The default value for this field.
@@ -375,7 +382,7 @@ class Field {
 		// Take care of common typos.
 		if ( 'theme_mods' === $this->option_type ) {
 			/* translators: %1$s represents the field ID where the error occurs. */
-			_doing_it_wrong( __METHOD__, sprintf( esc_html__( 'Typo found in field %s - "theme_mods" vs "theme_mod"', 'kirki' ), esc_html( $this->settings ) ), '3.0.10' );
+			_doing_it_wrong( __METHOD__, sprintf( esc_html( 'Typo found in field %s - "theme_mods" vs "theme_mod"', 'kirki' ), esc_html( $this->settings ) ), '3.0.10' );
 			$this->option_type = 'theme_mod';
 		}
 	}
@@ -577,7 +584,7 @@ class Field {
 		}
 
 		// Set transport to refresh initially.
-		// Serves as a fallback in case we failed to auto-calculate js_vars.
+		// Serves as a fallback in case we failt to auto-calculate js_vars.
 		$this->transport = 'refresh';
 
 		$js_vars = array();


### PR DESCRIPTION
…ation warning

Fix PHP 8.2 deprecation warning for dynamic $tab property

Added protected $tab property declaration to Field class to prevent  PHP 8.2+ deprecation warning when using tab parameter in Repeater fields.